### PR TITLE
Update Appraisals For Rails 7.0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        ruby: ['2.6', '2.7']
+        ruby: ['2.7']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/Appraisals
+++ b/Appraisals
@@ -7,3 +7,7 @@ end
 appraise "rails6.0" do
   gem "rails", "~> 6.0.2"
 end
+
+appraise "rails7.0" do
+  gem "rails", "~> 7.0.4"
+end


### PR DESCRIPTION
Seems to work fine with Rails 7 without any changes 🙂 