### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: '2.7'
       - name: Build and run tests
         env:
           REDIS_URL: redis://localhost:6379/0

--- a/.github/workflows/pronto-rubocop.yaml
+++ b/.github/workflows/pronto-rubocop.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
       - run: gem install rubocop pronto pronto-rubocop rubocop-performance rubocop-rspec rubocop-rails


### PR DESCRIPTION
- Replace deprecated action [actions/setup-ruby](https://github.com/ruby/setup-ruby) with [ruby/setup-ruby](https://github.com/ruby/setup-ruby)
- Use ruby 2.7

The failed pronto is due to me not having push access to the repo.