### PR TITLE
fix(fetching_hash_value): exception on expired entry

### DIFF
--- a/lib/active_support/cache/redis_hash_store.rb
+++ b/lib/active_support/cache/redis_hash_store.rb
@@ -22,7 +22,7 @@ module ActiveSupport
 
           if entry
             if entry.expired?
-              delete_hash_entry(key)
+              delete_hash_entry(prefix, key)
               payload[:hit] = false if payload
               nil
             else


### PR DESCRIPTION
Fetching a hash value throws an exception and fails to delete once the value is expired because the prefix isn't being passed to `delete_hash_entry`.
```
Wrong number of arguments (given 1, expected 2)
```